### PR TITLE
nvmesh_attach_volumes - adjustment to new exit codes

### DIFF
--- a/driver/common.py
+++ b/driver/common.py
@@ -139,13 +139,10 @@ class Utils(object):
 		cmd = cmd_template.format(access=nvmesh_access_mode, volume=nvmesh_volume_name)
 		exit_code, stdout, stderr = Utils.run_command(cmd)
 
-		if exit_code != 0:
-			cmd2_template = 'python /host/bin/nvmesh_attach_volumes --wait_for_attach --access {access} {volume}'
-			cmd2 = cmd_template.format(access=nvmesh_access_mode, volume=nvmesh_volume_name)
-			Utils.run_command(cmd)
+		try:
+			results = json.loads(stdout)
+		except Exception as ex:
 			raise DriverError(grpc.StatusCode.INTERNAL, "nvmesh_attach_volumes failed: exit_code: {} stdout: {} stderr: {}".format(exit_code, stdout, stderr))
-
-		results = json.loads(stdout)
 
 		if results.get('status') == 'failed':
 			# General Script Failure


### PR DESCRIPTION
* adjustments to exit code changes in nvmesh_attach_volumes
* nvmesh_attach_volumes will now return exit code 1 if at least one volume failed to attach

Change-Id: I82f175eb86188679656b861edde7ba35e4b6adcd
Signed-off-by: Gil <gil.vitzinger@excelero.com>