### PR TITLE
Fix attribute name

### DIFF
--- a/driver/common.py
+++ b/driver/common.py
@@ -67,7 +67,7 @@ def CatchServerErrors(func):
 			exc_tb = exc_tb.tb_next
 			fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
 
-			if Config.PrintTraceBacks:
+			if Config.PRINT_TRACEBACKS:
 				import traceback
 				tb = traceback.format_exc()
 				print(tb)


### PR DESCRIPTION
Attribute `PrintTraceBacks` does not exist in Config whereas `PRINT_TRACEBACKS` exists.

This caused driver failure