### PR TITLE
Default sc creation condition, use values from values.yaml, instance related resource names

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/NOTES.txt
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/NOTES.txt
@@ -3,7 +3,7 @@
 ##################################
 
 1. Configuration: Make sure the following points to your NVMesh Management Server:
-kubectl --namespace {{ template "nvmesh-csi-driver.namespace" . }} get configmap nvmesh-csi-config
+kubectl --namespace {{ template "nvmesh-csi-driver.namespace" . }} get configmap {{ template "nvmesh-csi-driver.fullname" . }}-config
 
 2. Please visit https://www.excelero.com/nvmesh-csi-driver-guide for the NVMesh CSI Driver User Guide
 

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: nvmesh-csi-config
+  name: {{ template "nvmesh-csi-driver.fullname" . }}-config
   namespace: {{ template "nvmesh-csi-driver.namespace" . }}
   labels:
     {{- include "nvmesh-csi-driver.labels" . | nindent 4 }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/credentials.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/credentials.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nvmesh-credentials
+  name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
   namespace: {{ template "nvmesh-csi-driver.namespace" . }}
   labels:
     {{- include "nvmesh-csi-driver.labels" . | nindent 4 }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -53,12 +53,12 @@ spec:
             - name: MANAGEMENT_SERVERS
               valueFrom:
                 configMapKeyRef:
-                  name: nvmesh-csi-config
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-config
                   key: management.servers
             - name: MANAGEMENT_PROTOCOL
               valueFrom:
                 configMapKeyRef:
-                  name: nvmesh-csi-config
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-config
                   key: management.protocol
             - name: MANAGEMENT_USERNAME
               valueFrom:
@@ -110,7 +110,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: nvmesh-csi-config
+            name: {{ template "nvmesh-csi-driver.fullname" . }}-config
         - name: plugin-socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/{{ .Values.driverName }}/
@@ -173,12 +173,12 @@ spec:
             - name: MANAGEMENT_SERVERS
               valueFrom:
                 configMapKeyRef:
-                  name: nvmesh-csi-config
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-config
                   key: management.servers
             - name: MANAGEMENT_PROTOCOL
               valueFrom:
                 configMapKeyRef:
-                  name: nvmesh-csi-config
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-config
                   key: management.protocol
             - name: MANAGEMENT_USERNAME
               valueFrom:
@@ -231,7 +231,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: nvmesh-csi-config
+            name: {{ template "nvmesh-csi-driver.fullname" . }}-config
         - name: plugin-socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/{{ .Values.driverName }}/

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -63,12 +63,12 @@ spec:
             - name: MANAGEMENT_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: nvmesh-credentials
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: username
             - name: MANAGEMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nvmesh-credentials
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: password
           volumeMounts:
             - name: config-volume
@@ -183,12 +183,12 @@ spec:
             - name: MANAGEMENT_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: nvmesh-credentials
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: username
             - name: MANAGEMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: nvmesh-credentials
+                  name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: password
           volumeMounts:
             - name: config-volume

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -21,7 +21,23 @@ spec:
       labels:
         {{ include "nvmesh-csi-driver.labels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccount: {{ template "nvmesh-csi-driver.serviceAccountName" . }}
       containers:
         # NVMesh Driver
@@ -123,14 +139,21 @@ spec:
       labels:
         {{ include "nvmesh-csi-driver.labels" . | nindent 8 }}
         app.kubernetes.io/component: node-driver
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccount: {{ template "nvmesh-csi-driver.serviceAccountName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
+      {{- with .Values.nodeDriver.tolerations }}
       tolerations:
-        # This would make the DaemonSet to be deployed also on the master node
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-          operator: Exists
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         # NVMesh Driver
         - name: nvmesh-csi-driver

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/storage-classes.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/storage-classes.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.defaultStorageClasses }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -59,4 +60,5 @@ allowVolumeExpansion: true
 volumeBindingMode: Immediate
 parameters:
   vpg: DEFAULT_EC_SINGLE_TARGET_REDUNDANCY_VPG
+{{- end }}
 {{- end }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
@@ -65,7 +65,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: nvmesh-csi-driver
+  name:
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
@@ -21,6 +21,8 @@ config:
 hostBinariesPath: /bin
 systemdHost: true
 
+defaultStorageClasses: true
+
 controller:
   replicaCount: 1
 

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
@@ -25,6 +25,12 @@ defaultStorageClasses: true
 
 controller:
   replicaCount: 1
+  tolerations: []
+nodeDriver:
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+      operator: Exists
 
 image:
   repository: excelero/nvmesh-csi-driver
@@ -77,8 +83,6 @@ service:
   port: 80
 
 nodeSelector: {}
-
-tolerations: []
 
 affinity: {}
 


### PR DESCRIPTION
Some improvements to enable multiple instanciations in the same cluster (and same namespace)
- Condition the creation of storage classes
- ConfigMap and Secret names are calculated instead of being hardcoded
- Tolerations are defined per component (controller, nodeDriver) instead of globally
- nodeSelector, annotations, affinity defined in values.yaml are now effectively used in templates
- serviceAccount name is by default undefined to let it be calculated

