### PR TITLE
Use DriverName as effective driver name in CSIDriver code

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
           env:
             - name: DRIVER_TYPE
               value: "Controller"
+            - name: DRIVER_NAME
+              value: "{{ .Values.driverName }}"
             - name: SOCKET_PATH
               value: unix:///csi/ctrl-csi.sock
             - name: MANAGEMENT_SERVERS
@@ -145,6 +147,8 @@ spec:
           env:
             - name: DRIVER_TYPE
               value: "Node"
+            - name: DRIVER_NAME
+              value: "{{ .Values.driverName }}"
             - name: SOCKET_PATH
               value: unix:///csi/csi.sock
             - name: MANAGEMENT_SERVERS

--- a/driver/config.py
+++ b/driver/config.py
@@ -13,6 +13,7 @@ class Config(object):
 	MANAGEMENT_USERNAME = None
 	MANAGEMENT_PASSWORD = None
 	SOCKET_PATH = None
+	DRIVER_NAME = None
 	ATTACH_IO_ENABLED_TIMEOUT = None
 	PRINT_TRACEBACKS = None
 
@@ -56,6 +57,7 @@ class ConfigLoader(object):
 		Config.MANAGEMENT_USERNAME = ConfigLoader._get_env_var_or_default('MANAGEMENT_USERNAME', default='admin@excelero.com')
 		Config.MANAGEMENT_PASSWORD = ConfigLoader._get_env_var_or_default('MANAGEMENT_PASSWORD', default='admin')
 		Config.SOCKET_PATH = ConfigLoader._get_env_var_or_default('SOCKET_PATH', default=Consts.DEFAULT_UDS_PATH)
+		Config.DRIVER_NAME = ConfigLoader._get_env_var_or_default('DRIVER_NAME', default=Consts.DEFAULT_DRIVER_NAME)
 
 		jsonConfig = ConfigLoader._get_json_config()
 		Config.ATTACH_IO_ENABLED_TIMEOUT = jsonConfig.get('attach_io_enabled_timeout', 30)
@@ -64,7 +66,7 @@ class ConfigLoader(object):
 		if not Config.MANAGEMENT_SERVERS:
 			raise ConfigError("MANAGEMENT_SERVERS environment variable not found or is empty")
 
-		print("Loaded Config with SOCKET_PATH={} ,MANAGEMENT_SERVERS={}".format(Config.SOCKET_PATH, Config.MANAGEMENT_SERVERS))
+		print("Loaded Config with SOCKET_PATH={}, MANAGEMENT_SERVERS={}, DRIVER_NAME={}".format(Config.SOCKET_PATH, Config.MANAGEMENT_SERVERS, Config.DRIVER_NAME))
 
 
 ConfigLoader.load()

--- a/driver/consts.py
+++ b/driver/consts.py
@@ -17,7 +17,7 @@ def read_bash_file(filename):
 	return l
 
 DEFAULT_VOLUME_SIZE = 5000000000 #5GB
-DRIVER_NAME = "nvmesh-csi.excelero.com"
+DEFAULT_DRIVER_NAME = "nvmesh-csi.excelero.com"
 DRIVER_VERSION = read_value_from_file("/version")
 SPEC_VERSION = "1.1.0"
 NVMESH_VERSION_INFO = read_bash_file('/opt/NVMesh/client-repo/version')

--- a/driver/identity_service.py
+++ b/driver/identity_service.py
@@ -1,5 +1,6 @@
 import google as google
 
+import config as Config
 import consts as Consts
 from csi.csi_pb2 import GetPluginInfoResponse, ProbeResponse, GetPluginCapabilitiesResponse, PluginCapability
 from csi.csi_pb2_grpc import IdentityServicer
@@ -11,7 +12,7 @@ class NVMeshIdentityService(IdentityServicer):
 		self.logger = logger
 
 	def GetPluginInfo(self, request, context):
-		name = Consts.DRIVER_NAME
+		name = Config.DRIVER_NAME
 		vendor_version = Consts.DRIVER_VERSION
 		# OPTIONAL FIELD: map <string, string> manifest = 3;
 		return GetPluginInfoResponse(name=name, vendor_version=vendor_version)

--- a/test/sanity/test_identity.py
+++ b/test/sanity/test_identity.py
@@ -11,7 +11,7 @@ class TestIdentityService(TestCaseWithServerRunning):
 	def test_get_plugin_info(self):
 		identityClient = IdentityClient()
 		msg = identityClient.GetPluginInfo()
-		self.assertEqual(msg.name, Consts.DRIVER_NAME)
+		self.assertEqual(msg.name, Consts.DEFAULT_DRIVER_NAME)
 		self.assertEqual(msg.vendor_version, Consts.DRIVER_VERSION)
 
 	@CatchRequestErrors


### PR DESCRIPTION
This PR makes the Identity service use the `driverName` provided in values.yml as effective driver name.
It enables multiple instanciations towards different NVMesh clusters across the same k8s cluster