### PR TITLE
Fix PSP to take hostBinariesPath and systemdHost from values.yaml into account

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/psp.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/psp.yaml
@@ -11,10 +11,12 @@ spec:
   allowedHostPaths:
   - pathPrefix: /var/lib/kubelet/
   - pathPrefix: /dev
-  - pathPrefix: /bin
+  - pathPrefix: {{ .Values.hostBinariesPath }}
   - pathPrefix: /var/opt/NVMesh
   - pathPrefix: /opt/NVMesh
+{{ if .Values.systemdHost }}
   - pathPrefix: /run/systemd/journal
+{{ end }}
   allowedCapabilities:
   - 'SYS_ADMIN'
   volumes:


### PR DESCRIPTION
Hostpath for binaries is hardcoded to /bin and should use `hostBinariesPath` from values.yaml.

In the same way but less blocking, `/run/systemd/journal` in hostpaths in conditioned to the value of the boolean `systemdHost` from values.yaml