### PR TITLE
Ability to set hostNetwork for controller pod

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
       serviceAccount: {{ template "nvmesh-csi-driver.serviceAccountName" . }}
       containers:
         # NVMesh Driver

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
@@ -35,6 +35,7 @@ defaultStorageClasses: true
 controller:
   replicaCount: 1
   tolerations: []
+  hostNetwork: false
 nodeDriver:
   tolerations:
     - key: node-role.kubernetes.io/master


### PR DESCRIPTION
In some case, when pod network cannot/shoudn't reach storage network, controller may benefit from hostNetwork.
This PR enables the Ability to set hostNetwork for controller pod