### PR TITLE
Use logToStdout instead of logToSysLog as CSIDriver components containerized

### DIFF
--- a/NVMeshSDK/ConnectionManager.py
+++ b/NVMeshSDK/ConnectionManager.py
@@ -38,13 +38,13 @@ class ConnectionManager:
 
     @staticmethod
     def getInstance(managementServer=None, user=DEFAULT_USERNAME, password=DEFAULT_PASSWORD,
-                 configFile=DEFAULT_NVMESH_CONFIG_FILE, logToSysLog=True):
+                 configFile=DEFAULT_NVMESH_CONFIG_FILE, logToStdout=True):
         if ConnectionManager.__instance is None:
-            ConnectionManager(managementServer, user, password, configFile, logToSysLog)
+            ConnectionManager(managementServer, user, password, configFile, logToStdout)
         return ConnectionManager.__instance
 
     def __init__(self, managementServer=None, user=DEFAULT_USERNAME, password=DEFAULT_PASSWORD,
-                 configFile=DEFAULT_NVMESH_CONFIG_FILE, logToSysLog=True):
+                 configFile=DEFAULT_NVMESH_CONFIG_FILE, logToStdout=True):
         if ConnectionManager.__instance is not None:
             raise Exception("This class is a singleton!")
         else:
@@ -55,7 +55,7 @@ class ConnectionManager:
             self.setManagementServer(managementServer)
             self.user = user
             self.password = password
-            self.logger = LoggerUtils.getLoggerWithHandler('ConnectionManager', logLevel=LoggerUtils.Consts.ManagementLogLevel.INFO, logToSysLog=logToSysLog)
+            self.logger = LoggerUtils.getLoggerWithHandler('ConnectionManager', logLevel=LoggerUtils.Consts.ManagementLogLevel.INFO, logToStdout=logToStdout)
             self.session = requests.session()
             self.isAlive()
 

--- a/NVMeshSDK/LoggerUtils.py
+++ b/NVMeshSDK/LoggerUtils.py
@@ -6,7 +6,7 @@ import traceback
 from logging.handlers import SysLogHandler
 from NVMeshSDK import Consts
 
-def getLoggerWithHandler(loggername, logToSysLog=True, logToStdout=False, logToStderr=False, logLevel=logging.DEBUG, propagate=True,
+def getLoggerWithHandler(loggername, logToSysLog=False, logToStdout=True, logToStderr=False, logLevel=logging.DEBUG, propagate=True,
 						formatString='%(name)s[{}]: %(levelname)s: %(message)s'.format(os.getpid())):
 	logger = logging.getLogger(loggername)
 	logger.propagate = propagate
@@ -39,6 +39,6 @@ def logStackTrace(ex, logger):
 	exc_type, exc_value, exc_traceback = sys.exc_info()
 	exString = traceback.format_exc()
 	errorLines = exString.split('\n')
-	
+
 	for line in errorLines:
 		logger.error(line)

--- a/driver/common.py
+++ b/driver/common.py
@@ -282,7 +282,7 @@ class NVMeshSDKHelper(object):
 
 		serversWithProtocol = ['{0}://{1}'.format(protocol, server) for server in managementServers.split(',')]
 
-		return ConnectionManager.getInstance(managementServer=serversWithProtocol, user=user, password=password, logToSysLog=False)
+		return ConnectionManager.getInstance(managementServer=serversWithProtocol, user=user, password=password, logToStdout=False)
 
 	@staticmethod
 	def init_sdk():

--- a/test/integration/tests/utils.py
+++ b/test/integration/tests/utils.py
@@ -802,7 +802,7 @@ class NVMeshUtils(object):
 		# try until able to connect to NVMesh Management
 		while not connected:
 			try:
-				ConnectionManager.getInstance(managementServer=[NVMESH_MGMT_ADDRESS], logToSysLog=False)
+				ConnectionManager.getInstance(managementServer=[NVMESH_MGMT_ADDRESS], logToStdout=False)
 				connected = ConnectionManager.getInstance().isAlive()
 			except ManagementTimeout as ex:
 				logger.info("Waiting for NVMesh Management server on {}".format(NVMESH_MGMT_ADDRESS))


### PR DESCRIPTION
Change defaults from logToSysLog to logToStdout as CSIDriver components are supposed to be containerized, and thus follow the best practice of stdout (or stderr log outputs) 