### PR TITLE
Ability to set log level for NodeDriver and Controller

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: password
+            - name: LOG_LEVEL
+              value: "{{ .Values.controller.logLevel }}"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
@@ -194,6 +196,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: password
+            - name: LOG_LEVEL
+              value: "{{ .Values.nodeDriver.logLevel }}"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
@@ -24,9 +24,11 @@ systemdHost: true
 defaultStorageClasses: true
 
 controller:
+  logLevel: info
   replicaCount: 1
   tolerations: []
 nodeDriver:
+  logLevel: info
   tolerations:
     - key: node-role.kubernetes.io/master
       effect: NoSchedule

--- a/driver/FileSystemManager.py
+++ b/driver/FileSystemManager.py
@@ -1,10 +1,11 @@
+import os
 import shutil
 
 from grpc import StatusCode
 
 from common import Utils, DriverLogger, DriverError
 
-logger = DriverLogger("FileSystemManager")
+logger = DriverLogger("FileSystemManager", level=os.environ.get('LOG_LEVEL', 'DEBUG').upper())
 
 class ArgumentError(Exception):
 	pass

--- a/driver/common.py
+++ b/driver/common.py
@@ -84,7 +84,7 @@ class DriverError(Exception):
 		self.code = code
 
 class Utils(object):
-	logger = DriverLogger("Utils")
+	logger = DriverLogger("Utils", level=Config.LOG_LEVEL)
 
 	@staticmethod
 	def volume_id_to_nvmesh_name(co_vol_name):
@@ -271,7 +271,7 @@ class Utils(object):
 
 
 class NVMeshSDKHelper(object):
-	logger = DriverLogger("NVMeshSDKHelper")
+	logger = DriverLogger("NVMeshSDKHelper", level=Config.LOG_LEVEL)
 
 	@staticmethod
 	def _try_get_sdk_instance():

--- a/driver/config.py
+++ b/driver/config.py
@@ -16,6 +16,7 @@ class Config(object):
 	DRIVER_NAME = None
 	ATTACH_IO_ENABLED_TIMEOUT = None
 	PRINT_TRACEBACKS = None
+	LOG_LEVEL = None
 
 class Parsers(object):
 	@staticmethod
@@ -58,6 +59,7 @@ class ConfigLoader(object):
 		Config.MANAGEMENT_PASSWORD = ConfigLoader._get_env_var_or_default('MANAGEMENT_PASSWORD', default='admin')
 		Config.SOCKET_PATH = ConfigLoader._get_env_var_or_default('SOCKET_PATH', default=Consts.DEFAULT_UDS_PATH)
 		Config.DRIVER_NAME = ConfigLoader._get_env_var_or_default('DRIVER_NAME', default=Consts.DEFAULT_DRIVER_NAME)
+		Config.LOG_LEVEL = ConfigLoader._get_env_var_or_default('LOG_LEVEL', default='DEBUG').upper()
 
 		jsonConfig = ConfigLoader._get_json_config()
 		Config.ATTACH_IO_ENABLED_TIMEOUT = jsonConfig.get('attach_io_enabled_timeout', 30)

--- a/driver/server.py
+++ b/driver/server.py
@@ -19,7 +19,7 @@ def log(msg):
 class NVMeshCSIDriverServer(object):
 	def __init__(self, driver_type):
 		self.driver_type = driver_type
-		self.logger = DriverLogger()
+		self.logger = DriverLogger(level=Config.LOG_LEVEL)
 		self.identity_service = NVMeshIdentityService(self.logger)
 
 		if self.driver_type == Consts.DriverType.Controller:


### PR DESCRIPTION
Currently, log level is hardcoded to debug.
With this PR, the current behaviour is the same in python code (default log level is debug when no LOG_LEVEL env var is set), but logLevel key has been added to values.yaml (and set to info)