### PR TITLE
Fix ClusterRole name for PSP use to avoid conflicts

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/psp.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/psp.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: psp.{{ template "nvmesh-csi-driver.fullname" . }}
+  name: {{ template "nvmesh-csi-driver.fullname" . }}
   labels:
 {{ include "nvmesh-csi-driver.labels" . | indent 4 }}
 spec:

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/rbac-permissions.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/rbac-permissions.yaml
@@ -259,17 +259,17 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "nvmesh-csi-driver.namespace" . }}-use-psp
+  name: psp:{{ template "nvmesh-csi-driver.fullname" . }}
 rules:
   - apiGroups: ["policy"]
-    resourceNames: ["psp.{{ template "nvmesh-csi-driver.fullname" . }}"]
+    resourceNames: ["{{ template "nvmesh-csi-driver.fullname" . }}"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "nvmesh-csi-driver.namespace" . }}-use-psp
+  name: {{ template "nvmesh-csi-driver.fullname" . }}:use-psp
 subjects:
   - kind: ServiceAccount
     name: {{ template "nvmesh-csi-driver.serviceAccountName" . }}


### PR DESCRIPTION
When instanciating multiple CSIdrivers in the same NS with PSP enabled, there is a conflict as the clusterRole name defined to use the PSP is based on the NS name.

That PR makes the clusterRole name based on the release fullname. It also remove the "psp." prefix from the PSP name (as redundant with the kind of the resource)