### PR TITLE
Fixes with topology

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
@@ -6,8 +6,10 @@ metadata:
   labels:
     {{- include "nvmesh-csi-driver.labels" . | nindent 4 }}
 data:
+{{- if and (not .Values.config.topology) (not .Values.config.topologyJsonFilePath) }}
   management.protocol: {{ .Values.config.protocol }}
   management.servers: {{ .Values.config.servers }}
+{{- end }}
   attachIOEnabledTimeout: "{{ .Values.config.attachIOEnabledTimeout }}"
   printStackTraces: "{{ .Values.config.printStackTraces }}"
 {{- if .Values.config.logLevel }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
@@ -21,9 +21,13 @@ data:
 {{- end }}
   csiConfigMapName: {{ template "nvmesh-csi-driver.fullname" . }}-config
   topologyConfigMapName: {{ template "nvmesh-csi-driver.fullname" . }}-topology
-{{- if .Values.config.topologyJsonFilePath }}
+{{- if or .Values.config.topology .Values.config.topologyJsonFilePath }}
   topology: |-
+{{- if .Values.config.topology }}
+{{ .Values.config.topology | toPrettyJson | indent 4 }}
+{{- else if .Values.config.topologyJsonFilePath }}
 {{ printf .Values.config.topologyJsonFilePath | .Files.Get | indent 4 }}
+{{- end }}
 {{- end }}
 ---
 kind: ConfigMap

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/configmaps.yaml
@@ -19,6 +19,8 @@ data:
 {{- if .Values.config.kubeClientLogLevel }}
   kubeClientLogLevel: {{ .Values.config.kubeClientLogLevel }}
 {{- end }}
+  csiConfigMapName: {{ template "nvmesh-csi-driver.fullname" . }}-config
+  topologyConfigMapName: {{ template "nvmesh-csi-driver.fullname" . }}-topology
 {{- if .Values.config.topologyJsonFilePath }}
   topology: |-
 {{ printf .Values.config.topologyJsonFilePath | .Files.Get | indent 4 }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/credentials.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/credentials.yaml
@@ -1,3 +1,4 @@
+{{- if and (not .Values.config.topology) (not .Values.config.topologyJsonFilePath) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   username: {{ .Values.config.username }}
   password: {{ .Values.config.password }}
+{{- end }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
               value: "{{ .Values.driverName }}"
             - name: SOCKET_PATH
               value: unix:///csi/ctrl-csi.sock
+{{- if and (not .Values.config.topology) (not .Values.config.topologyJsonFilePath) }}
             - name: MANAGEMENT_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -63,6 +64,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: password
+{{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /config
@@ -169,6 +171,7 @@ spec:
               value: "{{ .Values.driverName }}"
             - name: SOCKET_PATH
               value: unix:///csi/csi.sock
+{{- if and (not .Values.config.topology) (not .Values.config.topologyJsonFilePath) }}
             - name: MANAGEMENT_SERVERS
               valueFrom:
                 configMapKeyRef:
@@ -189,6 +192,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "nvmesh-csi-driver.fullname" . }}-credentials
                   key: password
+{{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /config

--- a/driver/config.py
+++ b/driver/config.py
@@ -90,10 +90,6 @@ def print_config():
 
 class ConfigLoader(object):
 	def load(self):
-		Config.MANAGEMENT_SERVERS = _get_config_map_param('management.servers') or _get_env_var('MANAGEMENT_SERVERS')
-		Config.MANAGEMENT_PROTOCOL = _get_config_map_param('management.protocol') or _get_env_var('MANAGEMENT_SERVERS', default='https')
-		Config.MANAGEMENT_USERNAME = _get_env_var('MANAGEMENT_USERNAME', default='admin@excelero.com')
-		Config.MANAGEMENT_PASSWORD = _get_env_var('MANAGEMENT_PASSWORD', default='admin')
 		Config.SOCKET_PATH = _get_env_var('SOCKET_PATH', default=Consts.DEFAULT_UDS_PATH)
 		Config.DRIVER_NAME = _get_env_var('DRIVER_NAME', default=Consts.DEFAULT_DRIVER_NAME)
 
@@ -110,6 +106,12 @@ class ConfigLoader(object):
 		Config.ZONE_MAX_DISABLED_TIME_IN_SECONDS = _get_config_map_param('zoneMaxDisabledTimeInSeconds', 120)
 		Config.TOPOLOGY_CONFIG_MAP_NAME = _get_config_map_param('topologyConfigMapName', 'nvmesh-csi-topology')
 		Config.CSI_CONFIG_MAP_NAME = _get_config_map_param('csiConfigMapName', 'nvmesh-csi-config')
+
+		if not Config.TOPOLOGY:
+		    Config.MANAGEMENT_SERVERS = _get_config_map_param('management.servers') or _get_env_var('MANAGEMENT_SERVERS')
+		    Config.MANAGEMENT_PROTOCOL = _get_config_map_param('management.protocol') or _get_env_var('MANAGEMENT_PROTOCOL', default='https')
+		    Config.MANAGEMENT_USERNAME = _get_env_var('MANAGEMENT_USERNAME', default='admin@excelero.com')
+		    Config.MANAGEMENT_PASSWORD = _get_env_var('MANAGEMENT_PASSWORD', default='admin')
 
 		ConfigValidator().validate()
 		print("Loaded Config with SOCKET_PATH={}, MANAGEMENT_SERVERS={}, DRIVER_NAME={}".format(Config.SOCKET_PATH, Config.MANAGEMENT_SERVERS, Config.DRIVER_NAME))

--- a/driver/server.py
+++ b/driver/server.py
@@ -53,7 +53,7 @@ class NVMeshCSIDriverServer(object):
 
 
 	def serve(self):
-		self.logger.info("Config Topology Type{}".format(Config.TOPOLOGY_TYPE))
+		self.logger.info("Config Topology Type {}".format(Config.TOPOLOGY_TYPE))
 
 		logging_interceptor = ServerLoggingInterceptor(self.logger)
 		self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), interceptors=(logging_interceptor,))


### PR DESCRIPTION
This PR brings some cleanings and fixes:

- Explicit definition of `csiConfigMapName` and `topologyConfigMapName` to work with any value of multipleCsiDrivers
- Add the ability to define topology as yaml directly in values.yaml instead using a json file  (which cannot be changed easily for multiples instanciations)
- Remove supernumerary env vars in templates when topology is used
- Fix Config.MANAGEMENT_* check when topology is used
- Minor fix in log display