### PR TITLE
target_path instead of block_device_publish_path in NodeUnpublishVolume for file

### DIFF
--- a/driver/node_service.py
+++ b/driver/node_service.py
@@ -191,7 +191,8 @@ class NVMeshNodeService(NodeServicer):
 			FileSystemManager.remove_dir(target_path)
 			if os.path.isdir(target_path):
 				raise DriverError(StatusCode.INTERNAL, 'node-driver unable to delete publish directory')
-		elif os.path.isfile(block_device_publish_path):
+		elif os.path.isfile(target_path):
+			self.logger.debug('NodeUnpublishVolume removing publish file: {}'.format(target_path))
 			os.remove(target_path)
 
 		return NodeUnpublishVolumeResponse()


### PR DESCRIPTION
Path to be tested should be `target_path` as it is the one to be removed.
At that point, `block_device_publish_path` should be already removed or an exception is raised if it cannot be removed.
If `block_device_publish_path` is still a file, that means `target_path` is a dir which wouldn't  be removed with `os.remove`