### PR TITLE
Add affinity in nodeDriver DS pod spec if defined

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -138,6 +138,10 @@ spec:
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       {{- with .Values.nodeDriver.tolerations }}
       tolerations:


### PR DESCRIPTION
`affinity` key in values.yaml is not taken into account in the DaemonSet spec.