### PR TITLE
Define nodeSelector and affinity separately for controller and nodeDriver

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/deployment.yaml
@@ -25,11 +25,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.controller.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
@@ -134,11 +134,11 @@ spec:
       {{- end }}
     spec:
       serviceAccount: {{ template "nvmesh-csi-driver.serviceAccountName" . }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.nodeDriver.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.nodeDriver.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
@@ -40,11 +40,15 @@ controller:
   replicaCount: 1
   tolerations: []
   hostNetwork: false
+  nodeSelector: {}
+  affinity: {}
 nodeDriver:
   tolerations:
     - key: node-role.kubernetes.io/master
       effect: NoSchedule
       operator: Exists
+  nodeSelector: {}
+  affinity: {}
 
 image:
   repository: excelero/nvmesh-csi-driver
@@ -95,10 +99,6 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
-
-nodeSelector: {}
-
-affinity: {}
 
 # overrideKubeVersion - this is to workaround the missing flag --kube-version (https://github.com/helm/helm/issues/7326)
 # we should use this only for templating (running `helm template ..`)


### PR DESCRIPTION
Required, for example, to have controller deployed on masters only.