### PR TITLE
Update kubernetes python library to 12.0.0 so that ServiceAccount token volume projection is handled

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ protobuf==3.15.0
 requests==2.24.0
 packaging==20.4
 websocket-client==0.56.0
-kubernetes==11.0.0
+kubernetes==12.0.0


### PR DESCRIPTION
Otherwise, on K8S clusters with BoundServiceAccountVolume enabled (such as 1.19 by default), after one hour the following log is raised
```
topology-service - ERROR - nvmesh-csi-driver-config ConfigMap watcher encountered an error, will retry in 60 seconds. Error: (401)
Reason: Unauthorized
HTTP response headers: HTTPHeaderDict({'Date': 'Mon, 11 Apr 2022 09:06:42 GMT', 'Audit-Id': 'ac3aa800-1fb7-4780-b99a-ae0d437bbe7d', 'Content-Length': '129', 'Content-Type': 'application/json', 'Cache-Control': 'no-cache, private'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}
```

NB: I picked 12.0.0 as the first version enabling periodic reload