### PR TITLE
Update CSIDriver API version to storage.k8s.io/v1 in helm chart

### DIFF
--- a/deploy/kubernetes/helm/nvmesh-csi-driver/templates/csi-driver.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/templates/csi-driver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: {{ .Values.csiDriverAPIVersion }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.driverName }}

--- a/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
+++ b/deploy/kubernetes/helm/nvmesh-csi-driver/values.yaml
@@ -111,3 +111,7 @@ service:
 # we should use this only for templating (running `helm template ..`)
 # usage `helm template ./nvmesh-csi-driver --set overrideKubeVersion=1.15
 overrideKubeVersion: false
+
+# The CSIDriver resource APIVersion.
+# storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+; use storage.k8s.io/v1
+csiDriverAPIVersion: storage.k8s.io/v1


### PR DESCRIPTION
Used as a variable to enable backwards-compat with kubernetes versions older than 1.22